### PR TITLE
fixes incorrect Protocol value.

### DIFF
--- a/src/Dns/DnsIpAddress.cs
+++ b/src/Dns/DnsIpAddress.cs
@@ -102,10 +102,10 @@ namespace Dns
         {
             // rotate octets
             var flippedAddress =
-                ((address << 24) & 0xFF_00_00_00) |
-                ((address << 16) & 0x00_FF_00_00) |
-                ((address >> 16) & 0x00_00_FF_00) |
-                ((address >> 24) & 0x00_00_00_FF);
+                ((address & 0x000000FF) << 24 ) |
+                ((address & 0x0000FF00) << 8 ) |
+                ((address & 0x00FF0000) >> 8 ) |
+                ((address & 0xFF000000) >> 24);
 
             return new DnsIpAddress(flippedAddress);
         }
@@ -141,7 +141,7 @@ namespace Dns
         {
             var index = 0;
             for (int i = 0; i < 4; i++)
-                index = ptrAddress.IndexOf('.', index);
+                index = ptrAddress.IndexOf('.', index + 1);
 
             var address = new DnsIpAddress(ptrAddress, 0, index);
             return address.GetFlipped();

--- a/src/Dns/DnsSRVRecord.cs
+++ b/src/Dns/DnsSRVRecord.cs
@@ -36,7 +36,9 @@ namespace Dns
             get
             {
                 var protocolStartIndex = Name.IndexOf('.') + 1;
-                return Name.Substring(protocolStartIndex, Name.IndexOf('.', protocolStartIndex));
+                var protocolEndIndex =  Name.IndexOf('.', Name.IndexOf(".") +1 );
+                var length = protocolEndIndex - protocolStartIndex;
+                return Name.Substring(protocolStartIndex, length);
             }
         }
 


### PR DESCRIPTION
Hey Gary, 

there was an issue with the protocol property, it uses the indexof incorrectly, meaning that is used the number of characters from the start of "Name" to the fist period "." to filter out the protocol name. This uses the "length" between the two dots.

the code can of course be sorter, but I added it like this to easily show the difference.

Esben